### PR TITLE
Implicit pg_controldata english declaring

### DIFF
--- a/script/pgsqlms
+++ b/script/pgsqlms
@@ -585,7 +585,8 @@ sub _get_controldata {
     my %controldata;
     my $ans;
 
-    $ans = qx{ $PGCTRLDATA "$datadir" 2>/dev/null };
+    # Implicit language declaring to avoid translation issues
+    $ans = qx{ LANG=en_US $PGCTRLDATA "$datadir" 2>/dev/null };
 
     # Parse the output of pg_controldata.
     # This output is quite stable between pg versions, but we might need to sort


### PR DESCRIPTION
Implicit english language declaring to avoid translation issues of `pg_controldata` (russian in my case). 
Reason. In my job I have to use the specific debian-based distro with localized PostgreSQL, so `pg_controldata` returns, for example, _"Состояние кластера БД"_ instead of _"Database cluster state"_ and then RA returns `OCF_ERR_INSTALLED`. This fix helped me a lot. Works both with 9.4 and 9.6